### PR TITLE
Hot-reload plan modal on file change

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3429,6 +3429,10 @@
             debouncedRefresh(data.sessionId, data.type === 'metadata-update');
           }
 
+          if (data.type === 'plan-update') {
+            refreshOpenPlan();
+          }
+
           if (data.type === 'team-update') {
             console.log('[SSE] Team update:', data.teamName);
             debouncedRefresh(data.teamName, false);
@@ -3783,6 +3787,20 @@
     }
 
     let _planSessionId = null;
+
+    function refreshOpenPlan() {
+      if (!_planSessionId || !document.getElementById('plan-modal').classList.contains('visible')) return;
+      fetch(`/api/sessions/${_planSessionId}/plan`)
+        .then(r => r.ok ? r.json() : null)
+        .then(data => {
+          if (data?.content) {
+            _pendingPlanContent = data.content;
+            const body = document.getElementById('plan-modal-body');
+            body.innerHTML = DOMPurify.sanitize(marked.parse(_pendingPlanContent));
+          }
+        })
+        .catch(() => {});
+    }
 
     function openPlanForSession(sid) {
       fetch(`/api/sessions/${sid}/plan`).then(r => r.ok ? r.json() : null).catch(() => null)

--- a/server.js
+++ b/server.js
@@ -706,6 +706,10 @@ plansWatcher.on('all', (event, filePath) => {
   if ((event === 'add' || event === 'change' || event === 'unlink') && filePath.endsWith('.md')) {
     lastMetadataRefresh = 0;
     broadcast({ type: 'metadata-update' });
+    if (event === 'change') {
+      const slug = path.basename(filePath, '.md');
+      broadcast({ type: 'plan-update', slug });
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- Adds `plan-update` SSE event when a plan `.md` file changes on disk
- Frontend auto-refreshes the plan modal content if it's currently visible
- No user action needed — editing a plan externally updates the modal in real-time

## Test plan
- [ ] Open a session with a plan, open the plan modal
- [ ] Edit the plan file externally (e.g. via "Open in Editor")
- [ ] Verify the modal content updates without closing/reopening