### PR TITLE
feat: support CLAUDE_CODE_TASK_LIST_ID for project-level task boards

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,8 +1,9 @@
 //#region STATE
 let sessions = [];
 let currentSessionId = null;
+let currentProjectPath = null;
 let currentTasks = [];
-let viewMode = 'session';
+let viewMode = 'session'; // 'session' | 'all' | 'project'
 let sessionFilter = 'active';
 let sessionLimit = '20';
 let filterProject = '__recent__'; // null = all, '__recent__' = last 24h, or project path
@@ -444,6 +445,52 @@ async function fetchTasks(sessionId) {
     currentSessionId = sessionId;
     lastCurrentTasksHash = '';
     updateUrl();
+    renderSession();
+  }
+}
+
+// Project view: loads the shared task board and combined agents for a project
+// with a custom task list (CLAUDE_CODE_TASK_LIST_ID)
+// biome-ignore lint/correctness/noUnusedVariables: used in HTML
+async function fetchProjectView(projectPath) {
+  try {
+    viewMode = 'project';
+    currentProjectPath = projectPath;
+
+    // Find the primary session for this project (for title/meta display)
+    const primarySession =
+      sessions.find((s) => s.customTaskListProject === projectPath) || sessions.find((s) => s.project === projectPath);
+    currentSessionId = primarySession?.id || null;
+
+    const encoded = encodeURIComponent(projectPath);
+    const [tasksRes, agentsRes] = await Promise.all([
+      fetch(`/api/projects/${encoded}/tasks`),
+      fetch(`/api/projects/${encoded}/agents`),
+    ]);
+
+    currentTasks = tasksRes.ok ? await tasksRes.json() : [];
+    const agentsData = agentsRes.ok ? await agentsRes.json() : { agents: [], waitingForUser: null };
+    currentAgents = agentsData.agents || [];
+    currentWaiting = agentsData.waitingForUser;
+
+    lastCurrentTasksHash = JSON.stringify(currentTasks);
+    ownerFilter = '';
+    lastMessagesHash = '';
+    lastInlineMessage = '';
+    document.getElementById('latest-message').classList.remove('visible');
+    currentPins = currentSessionId ? loadPins(currentSessionId) : {};
+
+    updateUrl();
+    renderSession();
+    renderAgentFooter();
+
+    // Also fetch messages from the primary session
+    if (currentSessionId) {
+      fetchMessages(currentSessionId);
+    }
+  } catch (error) {
+    console.error('Failed to fetch project view:', error);
+    currentTasks = [];
     renderSession();
   }
 }
@@ -1653,10 +1700,15 @@ function renderSessions() {
         .map((p, i) => (i < breadcrumbParts.length - 1 ? `${escapeHtml(p)}<span class="sep">/</span>` : escapeHtml(p)))
         .join('');
 
+      const hasCustomTaskList = projectSessions.some((s) => s.customTaskListProject);
+      const groupNameHtml = hasCustomTaskList
+        ? `<span class="group-name project-board-link" onclick="event.stopPropagation(); fetchProjectView('${escapedPath}')" title="Open project board">${escapeHtml(folderName)}</span>`
+        : `<span class="group-name">${escapeHtml(folderName)}</span>`;
+
       html += `
             <div class="project-group-header${isCollapsed ? ' collapsed' : ''}" data-group-path="${escapedPath}">
               <svg class="group-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
-              <span class="group-name">${escapeHtml(folderName)}</span>
+              ${groupNameHtml}
               <span class="group-count">${projectSessions.length}</span>
               <span class="group-path-toggle" data-group-action="toggle-path" title="Show full path">
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
@@ -1747,21 +1799,33 @@ function renderSession() {
   const session = sessions.find((s) => s.id === currentSessionId);
   if (!session) return;
 
-  const displayName =
-    session.customTitle || session.name || session.gitBranch || session.description || currentSessionId;
+  let displayName;
+  let metaParts;
+
+  if (viewMode === 'project' && currentProjectPath) {
+    // Project view: show project name as title
+    displayName = currentProjectPath.split('/').pop() || currentProjectPath;
+    metaParts = [`${currentTasks.length} tasks`, 'project board'];
+    const activeSessions = sessions.filter(
+      (s) => s.project === currentProjectPath && (s.hasActiveAgents || s.hasRunningAgents || s.hasRecentLog),
+    );
+    if (activeSessions.length > 0) {
+      metaParts.push(`${activeSessions.length} active session${activeSessions.length > 1 ? 's' : ''}`);
+    }
+  } else {
+    displayName = session.customTitle || session.name || session.gitBranch || session.description || currentSessionId;
+    const projectName = session.project ? session.project.split('/').pop() : null;
+    metaParts = [`${currentTasks.length} tasks`];
+    if (projectName) {
+      metaParts.push(projectName);
+    }
+    if (session.description && session.gitBranch) {
+      metaParts.push(session.description);
+    }
+    metaParts.push(formatDate(session.modifiedAt));
+  }
 
   sessionTitle.textContent = displayName;
-
-  // Build meta text with project path and description
-  const projectName = session.project ? session.project.split('/').pop() : null;
-  const metaParts = [`${currentTasks.length} tasks`];
-  if (projectName) {
-    metaParts.push(projectName);
-  }
-  if (session.description && session.gitBranch) {
-    metaParts.push(session.description);
-  }
-  metaParts.push(formatDate(session.modifiedAt));
   sessionMeta.textContent = metaParts.join(' · ');
 
   const completed = currentTasks.filter((t) => t.status === 'completed').length;

--- a/public/style.css
+++ b/public/style.css
@@ -2835,6 +2835,18 @@ select.form-input option:checked {
   white-space: nowrap;
 }
 
+.project-group-header .group-name.project-board-link {
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 3px;
+}
+
+.project-group-header .group-name.project-board-link:hover {
+  color: var(--accent);
+  text-decoration-style: solid;
+}
+
 .project-group-header .group-count {
   font-weight: 400;
   color: var(--text-muted);

--- a/server.js
+++ b/server.js
@@ -174,6 +174,110 @@ const compactSummaryCache = new Map();
 const taskCountsCache = new Map();
 const contextStatusCache = new Map();
 
+// Maps custom task list directory names to their project paths.
+// Built by scanning task files for metadata.project when the directory
+// name doesn't match any known session UUID.
+// e.g., { "my-project": "/Users/me/projects/my-project" }
+let customTaskListMap = {};
+let lastCustomTaskListScan = 0;
+const CUSTOM_TASK_LIST_SCAN_TTL = 10000;
+
+/**
+ * Scans non-UUID task directories for a metadata.project field in their
+ * task files. When CLAUDE_CODE_TASK_LIST_ID is set, tasks are stored under
+ * a custom directory name instead of a session UUID. This function discovers
+ * which project those tasks belong to so they can be associated with the
+ * correct session.
+ */
+function scanCustomTaskLists(metadata) {
+  const now = Date.now();
+  if (now - lastCustomTaskListScan < CUSTOM_TASK_LIST_SCAN_TTL) {
+    return customTaskListMap;
+  }
+
+  const map = {};
+  if (!existsSync(TASKS_DIR)) return map;
+
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  const dirs = readdirSync(TASKS_DIR, { withFileTypes: true }).filter(d => d.isDirectory());
+
+  for (const dir of dirs) {
+    // Skip UUID directories — those are normal session task dirs
+    if (UUID_RE.test(dir.name)) continue;
+    // Skip if already matched to a team session
+    if (metadata[dir.name]) continue;
+
+    const dirPath = path.join(TASKS_DIR, dir.name);
+    const files = readdirSync(dirPath).filter(f => f.endsWith('.json'));
+
+    // Read the first task file that has metadata.project
+    for (const file of files) {
+      try {
+        const task = JSON.parse(readFileSync(path.join(dirPath, file), 'utf8'));
+        if (task.metadata && task.metadata.project) {
+          map[dir.name] = task.metadata.project;
+          break;
+        }
+      } catch (e) { /* skip invalid */ }
+    }
+  }
+
+  customTaskListMap = map;
+  lastCustomTaskListScan = now;
+  return map;
+}
+
+/**
+ * Finds the most recent session for a given project path.
+ * Returns the session ID or null.
+ */
+/**
+ * Builds a reverse map: project path -> custom task list directory name.
+ */
+function getProjectToCustomListMap(metadata) {
+  const customLists = scanCustomTaskLists(metadata);
+  const map = {};
+  for (const [dirName, project] of Object.entries(customLists)) {
+    map[project] = dirName;
+  }
+  return map;
+}
+
+/**
+ * Decodes an encoded project directory name back to a filesystem path.
+ * e.g., "-Users-Robert-Sfeir-projects-foo" -> "/Users/Robert_Sfeir/projects/foo"
+ * Returns null if the input doesn't look encoded.
+ */
+function decodeProjectPath(encoded) {
+  if (!encoded || typeof encoded !== 'string') return null;
+  // Already a real path
+  if (encoded.startsWith('/')) return encoded;
+  // Encoded paths start with "-" (replacing the leading "/")
+  if (!encoded.startsWith('-')) return null;
+  return encoded.replace(/^-/, '/').replace(/-/g, '/');
+}
+
+function findActiveSessionForProject(project, metadata) {
+  let bestId = null;
+  let bestMtime = 0;
+
+  // Try exact match first, then decoded match
+  const decoded = decodeProjectPath(project);
+
+  for (const [sessionId, meta] of Object.entries(metadata)) {
+    const matches = meta.project === project ||
+      (decoded && meta.project === decoded);
+    if (!matches) continue;
+    const mtime = getSessionLogStat(meta).mtime || 0;
+    if (mtime > bestMtime) {
+      bestMtime = mtime;
+      bestId = sessionId;
+    }
+  }
+
+  return bestId;
+}
+
 function evictStaleCache(cache) {
   if (cache.size <= MAX_CACHE_ENTRIES) return;
   const oldest = cache.keys().next().value;
@@ -395,12 +499,19 @@ app.get('/api/sessions', async (req, res) => {
     const metadata = loadSessionMetadata();
     const sessionsMap = new Map();
 
+    // Discover custom task list directories (non-UUID dirs with metadata.project)
+    const customLists = scanCustomTaskLists(metadata);
+
     // First, add sessions that have tasks directories
     if (existsSync(TASKS_DIR)) {
       const entries = readdirSync(TASKS_DIR, { withFileTypes: true });
 
       for (const entry of entries) {
         if (entry.isDirectory()) {
+          // Skip custom task list directories — their tasks will be merged
+          // into the matching session below
+          if (customLists[entry.name]) continue;
+
           const sessionPath = path.join(TASKS_DIR, entry.name);
           const stat = statSync(sessionPath);
           const { taskCount, completed, inProgress, pending, newestTaskMtime } = getTaskCounts(sessionPath);
@@ -544,6 +655,65 @@ app.get('/api/sessions', async (req, res) => {
       } catch (e) { /* ignore */ }
     }
 
+    // Merge custom task list counts into matching project sessions.
+    // When CLAUDE_CODE_TASK_LIST_ID is set, tasks are stored under a custom
+    // directory name. Find the most recent session for that project and merge
+    // the task counts + tasksDir so the kanban displays them correctly.
+    for (const [dirName, project] of Object.entries(customLists)) {
+      const customPath = path.join(TASKS_DIR, dirName);
+      const counts = getTaskCounts(customPath);
+      if (counts.taskCount === 0) continue;
+
+      // Find the most recent session for this project
+      const targetSessionId = findActiveSessionForProject(project, metadata);
+      if (targetSessionId && sessionsMap.has(targetSessionId)) {
+        const session = sessionsMap.get(targetSessionId);
+        session.taskCount += counts.taskCount;
+        session.completed += counts.completed;
+        session.inProgress += counts.inProgress;
+        session.pending += counts.pending;
+        // Point tasksDir to the custom list so task fetching works
+        session.customTasksDir = customPath;
+        session.customTaskListProject = project;
+        if (counts.newestTaskMtime) {
+          const taskMtime = counts.newestTaskMtime.toISOString();
+          if (taskMtime > session.modifiedAt) session.modifiedAt = taskMtime;
+        }
+      } else {
+        // No matching session found — show as standalone project entry
+        const dirStat = statSync(customPath);
+        sessionsMap.set(dirName, {
+          id: dirName,
+          name: dirName,
+          slug: null,
+          project: project,
+          description: `Custom task list: ${dirName}`,
+          gitBranch: null,
+          customTitle: null,
+          taskCount: counts.taskCount,
+          completed: counts.completed,
+          inProgress: counts.inProgress,
+          pending: counts.pending,
+          createdAt: null,
+          modifiedAt: counts.newestTaskMtime ? counts.newestTaskMtime.toISOString() : dirStat.mtime.toISOString(),
+          isTeam: false,
+          memberCount: 0,
+          hasMessages: false,
+          hasActiveAgents: false,
+          hasRunningAgents: false,
+          hasWaitingForUser: false,
+          hasRecentLog: false,
+          jsonlPath: null,
+          tasksDir: customPath,
+          projectDir: null,
+          contextStatus: null,
+          hasPlan: false,
+          planTitle: null,
+          planPath: null,
+        });
+      }
+    }
+
     // Hide leader UUID sessions that are represented by a team session
     const teamLeaderIds = new Set();
     for (const [sid, session] of sessionsMap) {
@@ -659,25 +829,160 @@ app.get('/api/projects', (req, res) => {
   res.json(projects);
 });
 
+// API: Get tasks for a project's custom task list
+// Used by the project view to show the shared task board
+app.get('/api/projects/:encodedPath/tasks', async (req, res) => {
+  try {
+    const encodedPath = req.params.encodedPath;
+    const metadata = loadSessionMetadata();
+    const customListMap = getProjectToCustomListMap(metadata);
+
+    // Try the encoded path as-is, then decode it
+    let customListDir = customListMap[encodedPath];
+    if (!customListDir) {
+      const decoded = decodeProjectPath(encodedPath);
+      if (decoded) customListDir = customListMap[decoded];
+    }
+    // Also try matching by the real project path directly
+    if (!customListDir) {
+      for (const [project, dir] of Object.entries(customListMap)) {
+        if (project === encodedPath || decodeProjectPath(project) === encodedPath) {
+          customListDir = dir;
+          break;
+        }
+      }
+    }
+
+    if (!customListDir) {
+      return res.json([]);
+    }
+
+    const customPath = path.join(TASKS_DIR, customListDir);
+    if (!existsSync(customPath)) {
+      return res.json([]);
+    }
+
+    const taskFiles = readdirSync(customPath).filter(f => f.endsWith('.json'));
+    const tasks = [];
+    for (const file of taskFiles) {
+      try {
+        const task = JSON.parse(readFileSync(path.join(customPath, file), 'utf8'));
+        tasks.push(task);
+      } catch (e) { /* skip invalid */ }
+    }
+    tasks.sort((a, b) => parseInt(a.id) - parseInt(b.id));
+    res.json(tasks);
+  } catch (error) {
+    console.error('Error getting project tasks:', error);
+    res.status(500).json({ error: 'Failed to get project tasks' });
+  }
+});
+
+// API: Get agents across ALL sessions for a project
+// Used by the project view to show combined agents
+app.get('/api/projects/:encodedPath/agents', (req, res) => {
+  try {
+    const encodedPath = req.params.encodedPath;
+    const metadata = loadSessionMetadata();
+    const decoded = decodeProjectPath(encodedPath);
+    const targetProject = decoded || encodedPath;
+
+    // Find all sessions for this project
+    const projectSessionIds = [];
+    for (const [sessionId, meta] of Object.entries(metadata)) {
+      if (meta.project === targetProject || meta.project === encodedPath) {
+        projectSessionIds.push(sessionId);
+      }
+    }
+
+    const allAgents = [];
+    let waitingForUser = null;
+
+    for (const sessionId of projectSessionIds) {
+      const agentDir = path.join(AGENT_ACTIVITY_DIR, sessionId);
+      if (!existsSync(agentDir)) continue;
+
+      const meta = metadata[sessionId] || {};
+      const logMtime = getSessionLogStat(meta).mtime;
+      const sessionStale = logMtime ? (Date.now() - logMtime) > AGENT_STALE_MS : true;
+
+      const files = readdirSync(agentDir).filter(f => f.endsWith('.json') && !f.startsWith('_'));
+      for (const file of files) {
+        try {
+          const agent = JSON.parse(readFileSync(path.join(agentDir, file), 'utf8'));
+          const agentStale = !sessionStale && agent.updatedAt && (Date.now() - new Date(agent.updatedAt).getTime()) > AGENT_STALE_MS;
+          if (!isAgentFresh(agent) || sessionStale || agentStale) {
+            if (agent.status === 'active' || agent.status === 'idle') {
+              agent.status = 'stopped';
+              if (!agent.stoppedAt) agent.stoppedAt = agent.updatedAt || agent.startedAt;
+            }
+          }
+          // Tag with session so the UI can show which session the agent belongs to
+          agent._sessionId = sessionId;
+          const sessionMeta = metadata[sessionId];
+          agent._sessionName = sessionMeta?.slug || sessionMeta?.customTitle || sessionId.slice(0, 8);
+          allAgents.push(agent);
+        } catch (e) { /* skip invalid */ }
+      }
+
+      if (!waitingForUser) {
+        waitingForUser = checkWaitingForUser(agentDir, logMtime);
+      }
+    }
+
+    res.json({ agents: allAgents, waitingForUser });
+  } catch (e) {
+    console.error('Error getting project agents:', e);
+    res.json({ agents: [], waitingForUser: null });
+  }
+});
+
 // API: Get tasks for a session
 app.get('/api/sessions/:sessionId', async (req, res) => {
   try {
     const sessionPath = path.join(TASKS_DIR, req.params.sessionId);
-
-    if (!existsSync(sessionPath)) {
-      return res.status(404).json({ error: 'Session not found' });
-    }
-
-    const taskFiles = readdirSync(sessionPath).filter(f => f.endsWith('.json'));
     const tasks = [];
 
-    for (const file of taskFiles) {
-      try {
-        const task = JSON.parse(readFileSync(path.join(sessionPath, file), 'utf8'));
-        tasks.push(task);
-      } catch (e) {
-        console.error(`Error parsing ${file}:`, e);
+    // Read tasks from the session's own task directory
+    if (existsSync(sessionPath)) {
+      const taskFiles = readdirSync(sessionPath).filter(f => f.endsWith('.json'));
+      for (const file of taskFiles) {
+        try {
+          const task = JSON.parse(readFileSync(path.join(sessionPath, file), 'utf8'));
+          tasks.push(task);
+        } catch (e) {
+          console.error(`Error parsing ${file}:`, e);
+        }
       }
+    }
+
+    // Include custom task list tasks if this session is the primary
+    // (most recent) for its project. This ensures clicking the session
+    // card in the sidebar shows the same tasks as the merged count.
+    const metadata = loadSessionMetadata();
+    const meta = metadata[req.params.sessionId];
+    if (meta?.project) {
+      const customListDir = getProjectToCustomListMap(metadata)[meta.project];
+      if (customListDir) {
+        const primarySession = findActiveSessionForProject(meta.project, metadata);
+        if (primarySession === req.params.sessionId) {
+          const customPath = path.join(TASKS_DIR, customListDir);
+          if (existsSync(customPath)) {
+            const customFiles = readdirSync(customPath).filter(f => f.endsWith('.json'));
+            for (const file of customFiles) {
+              try {
+                const task = JSON.parse(readFileSync(path.join(customPath, file), 'utf8'));
+                task._customTaskList = customListDir;
+                tasks.push(task);
+              } catch (e) { /* skip invalid */ }
+            }
+          }
+        }
+      }
+    }
+
+    if (tasks.length === 0 && !existsSync(sessionPath)) {
+      return res.status(404).json({ error: 'Session not found' });
     }
 
     // Sort by ID (numeric)

--- a/test/custom-task-lists.test.js
+++ b/test/custom-task-lists.test.js
@@ -1,0 +1,322 @@
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// ---------------------------------------------------------------------------
+// Test helpers: create a temp directory structure that mimics ~/.claude/
+// ---------------------------------------------------------------------------
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'kanban-test-'));
+}
+
+function writeJson(filePath, data) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Extract pure functions from server.js for unit testing.
+// These are copy-pasted to avoid modifying the server module structure.
+// If the server is refactored to export these, replace with imports.
+// ---------------------------------------------------------------------------
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function decodeProjectPath(encoded) {
+  if (!encoded || typeof encoded !== 'string') return null;
+  if (encoded.startsWith('/')) return encoded;
+  if (!encoded.startsWith('-')) return null;
+  return encoded.replace(/^-/, '/').replace(/-/g, '/');
+}
+
+function scanCustomTaskListsSync(tasksDir, metadata) {
+  const map = {};
+  if (!fs.existsSync(tasksDir)) return map;
+
+  const dirs = fs.readdirSync(tasksDir, { withFileTypes: true }).filter(d => d.isDirectory());
+
+  for (const dir of dirs) {
+    if (UUID_RE.test(dir.name)) continue;
+    if (metadata[dir.name]) continue;
+
+    const dirPath = path.join(tasksDir, dir.name);
+    const files = fs.readdirSync(dirPath).filter(f => f.endsWith('.json'));
+
+    for (const file of files) {
+      try {
+        const task = JSON.parse(fs.readFileSync(path.join(dirPath, file), 'utf8'));
+        if (task.metadata && task.metadata.project) {
+          map[dir.name] = task.metadata.project;
+          break;
+        }
+      } catch (e) { /* skip */ }
+    }
+  }
+
+  return map;
+}
+
+function findActiveSessionForProject(project, metadata, getLogMtime) {
+  let bestId = null;
+  let bestMtime = 0;
+  const decoded = decodeProjectPath(project);
+
+  for (const [sessionId, meta] of Object.entries(metadata)) {
+    const matches = meta.project === project ||
+      (decoded && meta.project === decoded);
+    if (!matches) continue;
+    const mtime = getLogMtime ? (getLogMtime(sessionId) || 0) : 0;
+    if (mtime > bestMtime) {
+      bestMtime = mtime;
+      bestId = sessionId;
+    }
+  }
+
+  return bestId;
+}
+
+function getProjectToCustomListMap(tasksDir, metadata) {
+  const customLists = scanCustomTaskListsSync(tasksDir, metadata);
+  const map = {};
+  for (const [dirName, project] of Object.entries(customLists)) {
+    map[project] = dirName;
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('decodeProjectPath', () => {
+  it('returns null for null/undefined/empty', () => {
+    assert.equal(decodeProjectPath(null), null);
+    assert.equal(decodeProjectPath(undefined), null);
+    assert.equal(decodeProjectPath(''), null);
+  });
+
+  it('returns the path as-is if it already starts with /', () => {
+    assert.equal(decodeProjectPath('/Users/me/projects/foo'), '/Users/me/projects/foo');
+  });
+
+  it('decodes an encoded path starting with -', () => {
+    assert.equal(decodeProjectPath('-Users-me-projects-foo'), '/Users/me/projects/foo');
+  });
+
+  it('returns null for strings that do not start with - or /', () => {
+    assert.equal(decodeProjectPath('some-random-string'), null);
+    assert.equal(decodeProjectPath('Users-me'), null);
+  });
+
+  it('returns null for non-string values', () => {
+    assert.equal(decodeProjectPath(42), null);
+    assert.equal(decodeProjectPath({}), null);
+  });
+});
+
+describe('scanCustomTaskListsSync', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns empty map when tasks dir does not exist', () => {
+    const result = scanCustomTaskListsSync(path.join(tmpDir, 'nonexistent'), {});
+    assert.deepEqual(result, {});
+  });
+
+  it('skips UUID-named directories', () => {
+    const uuidDir = path.join(tmpDir, '93deddc1-d604-4b18-8367-2e8ccce27cd1');
+    writeJson(path.join(uuidDir, '1.json'), {
+      id: '1', subject: 'test', status: 'pending',
+      metadata: { project: '/Users/me/projects/foo' }
+    });
+
+    const result = scanCustomTaskListsSync(tmpDir, {});
+    assert.deepEqual(result, {});
+  });
+
+  it('skips directories already in metadata (team sessions)', () => {
+    const customDir = path.join(tmpDir, 'my-project');
+    writeJson(path.join(customDir, '1.json'), {
+      id: '1', subject: 'test', status: 'pending',
+      metadata: { project: '/Users/me/projects/foo' }
+    });
+
+    const metadata = { 'my-project': { slug: 'team-session' } };
+    const result = scanCustomTaskListsSync(tmpDir, metadata);
+    assert.deepEqual(result, {});
+  });
+
+  it('discovers custom task list with metadata.project', () => {
+    const customDir = path.join(tmpDir, 'syntetiq');
+    writeJson(path.join(customDir, '1.json'), {
+      id: '1', subject: 'Pipeline', status: 'in_progress',
+      metadata: { agent: 'eva', project: '/Users/me/projects/syntetiq' }
+    });
+
+    const result = scanCustomTaskListsSync(tmpDir, {});
+    assert.deepEqual(result, { syntetiq: '/Users/me/projects/syntetiq' });
+  });
+
+  it('skips tasks without metadata.project', () => {
+    const customDir = path.join(tmpDir, 'no-project');
+    writeJson(path.join(customDir, '1.json'), {
+      id: '1', subject: 'test', status: 'pending',
+      metadata: { agent: 'eva' }
+    });
+
+    const result = scanCustomTaskListsSync(tmpDir, {});
+    assert.deepEqual(result, {});
+  });
+
+  it('reads project from first task that has it', () => {
+    const customDir = path.join(tmpDir, 'my-app');
+    writeJson(path.join(customDir, '1.json'), {
+      id: '1', subject: 'no project', status: 'pending', metadata: {}
+    });
+    writeJson(path.join(customDir, '2.json'), {
+      id: '2', subject: 'has project', status: 'pending',
+      metadata: { project: '/home/user/my-app' }
+    });
+
+    const result = scanCustomTaskListsSync(tmpDir, {});
+    assert.deepEqual(result, { 'my-app': '/home/user/my-app' });
+  });
+
+  it('handles multiple custom task list directories', () => {
+    writeJson(path.join(tmpDir, 'project-a', '1.json'), {
+      id: '1', subject: 'a', status: 'pending',
+      metadata: { project: '/projects/a' }
+    });
+    writeJson(path.join(tmpDir, 'project-b', '1.json'), {
+      id: '1', subject: 'b', status: 'pending',
+      metadata: { project: '/projects/b' }
+    });
+
+    const result = scanCustomTaskListsSync(tmpDir, {});
+    assert.equal(result['project-a'], '/projects/a');
+    assert.equal(result['project-b'], '/projects/b');
+  });
+
+  it('skips invalid JSON files gracefully', () => {
+    const customDir = path.join(tmpDir, 'bad-json');
+    fs.mkdirSync(customDir, { recursive: true });
+    fs.writeFileSync(path.join(customDir, '1.json'), 'not valid json');
+    writeJson(path.join(customDir, '2.json'), {
+      id: '2', subject: 'good', status: 'pending',
+      metadata: { project: '/good/path' }
+    });
+
+    const result = scanCustomTaskListsSync(tmpDir, {});
+    assert.deepEqual(result, { 'bad-json': '/good/path' });
+  });
+});
+
+describe('findActiveSessionForProject', () => {
+  it('returns null when no sessions match the project', () => {
+    const metadata = {
+      'session-1': { project: '/other/project' }
+    };
+    const result = findActiveSessionForProject('/my/project', metadata, () => 100);
+    assert.equal(result, null);
+  });
+
+  it('returns the session with the highest mtime', () => {
+    const metadata = {
+      'session-old': { project: '/my/project' },
+      'session-new': { project: '/my/project' },
+      'session-other': { project: '/other' },
+    };
+    const mtimes = { 'session-old': 100, 'session-new': 200, 'session-other': 300 };
+    const result = findActiveSessionForProject('/my/project', metadata, (id) => mtimes[id]);
+    assert.equal(result, 'session-new');
+  });
+
+  it('matches using decoded path when project is encoded', () => {
+    const metadata = {
+      'session-1': { project: '/Users/me/projects/foo' }
+    };
+    const result = findActiveSessionForProject('-Users-me-projects-foo', metadata, () => 100);
+    assert.equal(result, 'session-1');
+  });
+
+  it('prefers exact match over decoded match', () => {
+    const metadata = {
+      'session-exact': { project: '/my/project' },
+    };
+    const result = findActiveSessionForProject('/my/project', metadata, () => 100);
+    assert.equal(result, 'session-exact');
+  });
+
+  it('returns null for empty metadata', () => {
+    const result = findActiveSessionForProject('/my/project', {}, () => 100);
+    assert.equal(result, null);
+  });
+});
+
+describe('getProjectToCustomListMap', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns empty map when no custom task lists exist', () => {
+    const result = getProjectToCustomListMap(tmpDir, {});
+    assert.deepEqual(result, {});
+  });
+
+  it('builds reverse map from project path to directory name', () => {
+    writeJson(path.join(tmpDir, 'syntetiq', '1.json'), {
+      id: '1', subject: 'test', status: 'pending',
+      metadata: { project: '/Users/me/projects/syntetiq' }
+    });
+
+    const result = getProjectToCustomListMap(tmpDir, {});
+    assert.equal(result['/Users/me/projects/syntetiq'], 'syntetiq');
+  });
+
+  it('handles multiple projects', () => {
+    writeJson(path.join(tmpDir, 'app-a', '1.json'), {
+      id: '1', subject: 'a', status: 'pending',
+      metadata: { project: '/projects/a' }
+    });
+    writeJson(path.join(tmpDir, 'app-b', '1.json'), {
+      id: '1', subject: 'b', status: 'pending',
+      metadata: { project: '/projects/b' }
+    });
+
+    const result = getProjectToCustomListMap(tmpDir, {});
+    assert.equal(result['/projects/a'], 'app-a');
+    assert.equal(result['/projects/b'], 'app-b');
+  });
+});
+
+describe('UUID_RE', () => {
+  it('matches valid UUIDs', () => {
+    assert.ok(UUID_RE.test('93deddc1-d604-4b18-8367-2e8ccce27cd1'));
+    assert.ok(UUID_RE.test('6628b4b8-e51c-4861-ad64-be21ff8d0ec1'));
+    assert.ok(UUID_RE.test('AABBCCDD-1122-3344-5566-778899AABBCC'));
+  });
+
+  it('does not match non-UUID strings', () => {
+    assert.ok(!UUID_RE.test('syntetiq'));
+    assert.ok(!UUID_RE.test('my-project'));
+    assert.ok(!UUID_RE.test('not-a-uuid-at-all'));
+    assert.ok(!UUID_RE.test('93deddc1-d604-4b18-8367'));
+    assert.ok(!UUID_RE.test(''));
+  });
+});


### PR DESCRIPTION
## Summary

When `CLAUDE_CODE_TASK_LIST_ID` is set, Claude Code stores tasks under a custom directory name (e.g., `~/.claude/tasks/my-project/`) instead of the session UUID. The kanban couldn't associate these tasks with any session — they were invisible.

This adds **project-based task list discovery** and a **project view**:

### Server changes
- **`scanCustomTaskLists()`** — identifies non-UUID task directories and reads `metadata.project` from task files to determine which project they belong to
- **`findActiveSessionForProject()`** — finds the most recent session for a project, with `decodeProjectPath()` fallback for encoded directory names
- **Session list** — custom task list counts are merged into the primary session so the sidebar shows correct task counts
- **Session tasks** — the primary session's task endpoint includes custom list tasks; other sessions show only their own
- **`GET /api/projects/:path/tasks`** — returns tasks from the custom task list
- **`GET /api/projects/:path/agents`** — aggregates agents from ALL sessions for a project

### Frontend changes
- Projects with custom task lists get a **clickable project name** (dotted underline) in the sidebar group header
- Clicking it opens a **project view** with the shared task board + combined agents from all sessions
- Individual session cards remain clickable for session-specific views
- Non-custom-list projects are completely unaffected

### Contract for task producers
Include `metadata.project` in task JSON — the real filesystem project path:
```json
{
  "metadata": {
    "project": "/Users/me/projects/my-app"
  }
}
```

### Tests
- 23 new unit tests covering `decodeProjectPath`, `scanCustomTaskLists`, `findActiveSessionForProject`, `getProjectToCustomListMap`, and `UUID_RE`
- All 41 existing contract tests pass unchanged

## Test plan
- [x] Custom task list tasks appear on the correct session's board
- [x] Task counts (completed/in-progress/pending) are accurate
- [x] Non-primary sessions show 0 tasks (their own, not the custom list)
- [x] Non-custom-list projects are completely unaffected
- [x] "Active Only" filter correctly shows/hides sessions
- [x] Project view loads combined agents from all sessions
- [x] 64 total tests pass (41 existing + 23 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)