### PR TITLE
ci: add npm caching and update Biome schema to 2.4.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - run: npm ci
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "formatter": {
     "enabled": true,
     "indentStyle": "space",


### PR DESCRIPTION
## Summary

- Add `cache: 'npm'` to `actions/setup-node` in CI for faster installs on warm cache
- Bump `biome.json` `$schema` from 2.4.7 to 2.4.10 (metadata only, no rule changes)

Closes #21

## Test plan

- [x] `npx @biomejs/biome check --error-on-warnings public/app.js public/style.css` — no issues
- [x] `node -c server.js` — syntax OK
- [x] `npm test` — 62/62 tests pass